### PR TITLE
Add tree-based menu options

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ _G.my_quit_menu = function()
       else
         vim.api.nvim_command("echo 'Phew!'")
       end
+      return true
     end
   }
 end
@@ -46,8 +47,11 @@ end
 nvim.nvim_command("command! -nargs=0 QuitMenu lua my_quit_menu()")
 ```
 
-The public function `ask` takes a question, some options and a handler function.
-Additionally, it takes a `quitable` option, which conveniently creates a `quit` option of you.
+The public function `ask` takes:
+- `question`: The message on the prompt;
+- `options`: A sequence of options, as described below;
+- `handler`: a function that takes the session and the chosen option and returns a boolean on whether it should close the prompt;
+- `[quitable]`: Whether the prompt should contain a default option `q` that just closes the prompt.
 
 The options consit of:
 - `item`: the value that your handler function will receive;
@@ -55,13 +59,27 @@ The options consit of:
 - `[key]`: The key that will be bound to that option.
   - If not supplied, it will try to get the best possible option from the description.
 
+Optionally, you could give a map instead of an array:
+```lua
+{
+  item = {
+    description = "..."
+  },
+  other = {
+    description = "..."
+  }
+}
+```
+
+This is required for creating tree-based prompts. Please read more about [tree-based prompts on docs/tree-based.md](docs/tree-based.md)
+
 That's it! Quick and simple!
 
 ## TODO
 
+- [x] [Tree-based prompts](docs/tree-based.md)
 - [ ] Fuzzy finder
 - [ ] Highlighting
 - [ ] Drawing enhancements
 - [ ] Restoring previous session
 - [ ] Async capabilities
-- [ ] Tree-based prompts

--- a/docs/tree-based.md
+++ b/docs/tree-based.md
@@ -1,0 +1,38 @@
+# Implementing tree-based prompts
+
+This is a small documentation for tree-based prompts.
+
+## How it works?
+
+It is the same thing as the normal ones, except that you can have multiple levels before handling the option.
+
+On your handle function, you'll receive the session object, which contains the `breadcrumbs` object.
+
+It is both the breadcrumbs for the display and the 'lens' for selecting the nested options.
+
+## How to
+
+You'll need to supply a `children` key to your options.
+
+```lua
+{
+  options = {
+    item = {
+      description = "Tree option",
+      children = {
+        child = {
+          description = "Child value"
+        },
+        leaf = {
+          description = "Leaf value"
+        }
+      }
+    },
+  handler = function(...)
+  -- ..
+  end
+}
+```
+
+Note that it either traverses the tree or calls the handler, meaning that only "leaf" objects will trigger the provided function.
+

--- a/lua/impromptu/init.lua
+++ b/lua/impromptu/init.lua
@@ -58,90 +58,141 @@ impromptu.ll.sub_div = function(sz)
   return string.rep("•", sz)
 end
 
-impromptu.ll.render = function(obj)
-  local content = {}
+impromptu.ll.window_for_obj = function(obj)
+  obj = impromptu.ll.show(obj)
 
   local winnr = nvim.nvim_call_function("bufwinnr", {obj.buffer})
   local window = nvim.nvim_call_function("win_getid", {winnr})
-
   local sz = nvim.nvim_win_get_width(window)
   local h = nvim.nvim_win_get_height(window)
-  local has_footer = obj.footer and true or false
-  local footer_sz = has_footer and 2 or 0
 
-  local selected = {q = 1}
+  return {
+    window = window,
+    width = sz,
+    height = h
+  }
+end
 
-  nvim.nvim_command("mapclear <buffer>")
-
-  if obj.header ~= nil then
-    local header = obj.header
-    local up = nil
-
-    if #obj.breadcrumbs >= 1 then
-       header = header .. " [" ..table.concat(obj.breadcrumbs, "/") .. "]"
-
-      up = impromptu.ll.line{
-        key = "h",
-        description = "Move up one level",
-      }
-
-    nvim.nvim_command("map <buffer> h <Cmd>lua require('impromptu').core.callback("  .. obj.session .. ", '__up')<CR>")
-
-    selected.h = 1
-    end
-
-    table.insert(content, header)
-    table.insert(content, impromptu.ll.div(sz))
-    table.insert(content, "")
-
-    if up ~= nil then
-      table.insert(content, up)
-    end
-  end
-
+impromptu.ll.get_options = function(obj)
+  local opts = {}
+  local selected = {}
   local process = function(item, line)
     local key = heuristics.get_unique_key(selected, line.description)
     selected[key] = 1
 
     line.key = key
+    line.item = item
+    return line
+  end
 
-    table.insert(content, impromptu.ll.line(line))
-    nvim.nvim_command("map <buffer> " .. line.key .. " <Cmd>lua require('impromptu').core.callback("  .. obj.session .. ", '" .. item .. "')<CR>")
+  if #obj.breadcrumbs >= 1 then
+    table.insert(opts, {
+        key = "h",
+        description = "Move up one level",
+        item = "__up"
+      })
+    selected.h = 1
+  end
+
+  if obj.quitable then
+    selected.q = 1
   end
 
   local line_lvl = utils.get_in(obj.lines, utils.interleave(obj.breadcrumbs, 'children'))
-
   if #line_lvl == 0 then
+    -- TODO sort those
     for item, line in pairs(line_lvl) do
-      process(item, line)
+      table.insert(opts, process(item, line))
     end
   else
     for _, line in ipairs(line_lvl) do
-      process(line.item, line)
+      table.insert(opts, process(line.item, line))
     end
   end
 
   if obj.quitable then
-    table.insert(content, impromptu.ll.line{
+    table.insert(opts, {
       key = "q",
-      item = "quit",
+      item = "__quit",
       description = "Close this prompt",
     })
-
-    nvim.nvim_command("map <buffer> q <Cmd>lua require('impromptu').core.destroy("  .. obj.session .. ")<CR>")
   end
 
-  if #content + footer_sz < h then
+  return opts
+end
+
+impromptu.ll.get_header = function(obj)
+  local header = ""
+
+  if obj.header ~= nil then
+    header = obj.header
+  end
+
+  if #obj.breadcrumbs >= 1 then
+     header = header .. " [" ..table.concat(obj.breadcrumbs, "/") .. "]"
+   end
+
+   return header
+ end
+
+impromptu.ll.get_footer = function(obj)
+  local footer = nil
+
+  if obj.footer ~= nil then
+    footer = obj.footer
+  end
+
+   return footer
+ end
+
+ impromptu.ll.do_mappings = function(obj, opts)
+  nvim.nvim_command("mapclear <buffer>")
+
+   for _, v in ipairs(opts) do
+     nvim.nvim_command("map <buffer> " .. v.key .. " <Cmd>lua require('impromptu').core.callback("  .. obj.session .. ", '" .. v.item .. "')<CR>")
+   end
+ end
+
+impromptu.ll.draw = function(obj, opts, window_ops)
+  local header = impromptu.ll.get_header(obj)
+  local footer = impromptu.ll.get_footer(obj)
+  local footer_sz = footer ~= "" and 2 or 1
+
+  local content = {}
+
+  if header ~= "" then
+    table.insert(content, header)
+    table.insert(content, impromptu.ll.div(window_ops.width))
+  end
+
+  table.insert(content, "")
+
+  for _, opt in ipairs(opts) do
+    table.insert(content, impromptu.ll.line(opt))
+  end
+
+  if #content + footer_sz < window_ops.height then
     local fill = h - #content  - footer_sz
     for _ = 1, fill do
       table.insert(content, "")
     end
   end
 
-  if has_footer then
-    table.insert(content, impromptu.ll.div(sz))
-    table.insert(content, obj.footer)
+  if footer ~= "" then
+    table.insert(content, impromptu.ll.div(window_ops.width))
+    table.insert(content, footer)
   end
+
+  return content
+ end
+
+impromptu.ll.render = function(obj)
+
+  local opts = impromptu.ll.get_options(obj)
+  local window_ops = impromptu.ll.window_for_obj(obj)
+
+  impromptu.ll.do_mappings(obj, opts)
+  local content = impromptu.ll.draw(obj, opts, window_ops)
 
   nvim.nvim_buf_set_lines(obj.buffer, 0, -1, false, content)
 end
@@ -168,7 +219,6 @@ impromptu.core.ask = function(args)
   obj.lines = args.options
   obj.handler = args.handler
 
-  obj = impromptu.ll.show(obj)
   obj = impromptu.ll.render(obj)
 
   return obj
@@ -200,12 +250,18 @@ impromptu.core.callback = function(session, option)
   local obj = impromptu.memory[session]
   local should_close = true
 
-  if obj ~= nil then
-    if impromptu.core.tree(obj, option) then
-      should_close = false
-    else
-      should_close = obj:handler(option)
-    end
+  if obj == nil then
+    -- TODO warning
+     return
+  elseif option == "__quit" then
+    impromptu.core.destroy(obj)
+    return
+  end
+
+  if impromptu.core.tree(obj, option) then
+    should_close = false
+  else
+    should_close = obj:handler(option)
   end
 
   if should_close then

--- a/lua/impromptu/samples.lua
+++ b/lua/impromptu/samples.lua
@@ -1,0 +1,48 @@
+local impromptu = require("impromptu")
+local nvim = vim.api
+
+_G.test_tree = function()
+  local opts = {
+    one = {
+      description = "Item 1",
+      children = {
+        eleven = {description = "Item 11"},
+        twelve = {description = "Item 12"},
+      }
+    },
+    two = {
+      description = "Item 2",
+      children = {
+        twentyone = {
+          description = "Item 21",
+          children = {
+            twohundredten = {description = "Item 210"}
+          }
+        },
+        twentytwo = {
+          description = "Item 22",
+          children = {
+            twohundredtwenty = {
+              description = "Item 220",
+              children = {
+                really = {description  = "Really?"},
+                no_way = {description  = "No way!"}
+              }
+            }
+          }
+        },
+      }
+    }
+  }
+
+  impromptu.core.ask{
+    question = "Navigate over the tree",
+    options = opts,
+    handler = function(_, opt)
+      print(opt)
+      return true
+    end
+  }
+end
+
+nvim.nvim_command("command! -nargs=0 TestTree lua test_tree()")

--- a/lua/impromptu/utils.lua
+++ b/lua/impromptu/utils.lua
@@ -39,4 +39,46 @@ utils.default = function(val, def)
   end
 end
 
+utils.get = function(d, k)
+  if type(d) == "table" then
+    return d and d[k]
+  else
+    return nil
+  end
+end
+
+utils.get_in = function(d, k)
+  local p = d
+  for _, i in ipairs(k) do
+    p = utils.get(p, i)
+  end
+
+  return p
+end
+
+utils.clone = function(orig)
+    local orig_type = type(orig)
+    local copy
+    if orig_type == 'table' then
+        copy = {}
+        for orig_key, orig_value in next, orig, nil do
+            copy[utils.clone(orig_key)] = utils.clone(orig_value)
+        end
+        setmetatable(copy, utils.clone(getmetatable(orig)))
+    else -- number, string, boolean, etc
+        copy = orig
+    end
+    return copy
+end
+
+utils.interleave = function(tbl, itn)
+  local new = {}
+  for _, v in ipairs(tbl) do
+    table.insert(new, v)
+    table.insert(new, itn)
+  end
+
+  return new
+end
+
 return utils


### PR DESCRIPTION
Adds the possibility to build tree-based (nested) menus/prompts.

Ping @KillTheMule  for the requested feature.

Sample code is provided by running `lua require("impromptu.samples")` and then `:TestTree`.