### PR TITLE
Adds <nowait> to the mapping procedure in the impromptu buffer.

### DIFF
--- a/lua/impromptu/internals/ask.lua
+++ b/lua/impromptu/internals/ask.lua
@@ -192,7 +192,7 @@ ask.get_header = function(obj)
 
    for _, v in ipairs(opts) do
      nvim.nvim_command(
-       "map <buffer> " ..
+       "map <nowait> <buffer> " ..
        v.key ..
        " <Cmd>lua require('impromptu').callback("  ..
        obj.session_id ..


### PR DESCRIPTION
When a global mapping expects more keys when invoked (e.g. Vim-Surround's surround operator), and that same global mapping conflicts with some option's key shortcut, **_even with the `<buffer>` qualifier_**, the shortcut won't resolve right away. This happened to me and is what motivated the PR.

It seems like <nowait> was created to solve conflicts like those. `:help :map-nowait`

```
						*:map-<nowait>* *:map-nowait*
When defining a buffer-local mapping for "," there may be a global mapping
that starts with ",".  Then you need to type another character for Vim to know
whether to use the "," mapping or the longer one.  To avoid this add the
<nowait> argument.  Then the mapping will be used when it matches, Vim does
not wait for more characters to be typed.  However, if the characters were
already typed they are used.
```